### PR TITLE
run everything with just `docker-compose up`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+bin/
 build/
 develop-eggs/
 dist/
@@ -15,7 +16,8 @@ downloads/
 eggs/
 .eggs/
 lib/
-lib64/
+lib64
+models/
 parts/
 sdist/
 var/
@@ -26,6 +28,12 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
+
+# User configs
+configs/client_config.json
+
+# Database
+mongo/
 
 # PyInstaller
 #  Usually these files are written by a python script from a template
@@ -65,11 +73,15 @@ db.sqlite3-journal
 instance/
 .webassets-cache
 
+# Crawler metadata
+crawler/fetch_times.json
+
 # Scrapy stuff:
 .scrapy
 
 # Sphinx documentation
 docs/_build/
+share/man/
 
 # PyBuilder
 target/
@@ -83,6 +95,7 @@ ipython_config.py
 
 # pyenv
 .python-version
+pyvenv.cfg
 
 # pipenv
 #   According to pypa/pipenv#598, it is recommended to include Pipfile.lock in version control.

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,18 @@
+# Use an official Python runtime as a parent image
+FROM debian:bookworm-slim
+
+# Set the working directory in the container
+WORKDIR /usr/src/app
+
+# Install 
+RUN apt-get update && \
+    apt-get install -y python3-pip wget && \
+    rm -rf /var/lib/apt/lists/*
+
+# Clone the repository
+COPY . .
+
+# Install any needed packages specified in requirements.txt
+RUN pip install --break-system-packages --no-cache-dir -r requirements.txt && \
+# Download models
+    bash download_models.sh

--- a/README.md
+++ b/README.md
@@ -14,48 +14,98 @@ Extensive description (in Russian): [Whitepaper](https://telegra.ph/NYAN-Whitepa
 
 Detailed instruction (in Russian): [Как поднять свой НЯН](https://github.com/NyanNyanovich/nyan/wiki/%D0%9A%D0%B0%D0%BA-%D0%BF%D0%BE%D0%B4%D0%BD%D1%8F%D1%82%D1%8C-%D1%81%D0%B2%D0%BE%D0%B9-%D0%9D%D0%AF%D0%9D)
 
+## Prerequisites
 
-## Install
+2 CPU cores, 8Gb RAM, 50Gb SSD
+Ubuntu 18.04 or higher
+Python 3.7 or higher
+Docker: [installation doc](https://docs.docker.com/engine/install)
+Docker Compose: [installation doc](https://docs.docker.com/compose/install)
 
-Install git and pip
-```
-sudo apt-get install git python3-pip
+Install the required packages
+
+```shell
+sudo apt-get install git git-lfs python3-pip wget
 ```
 
 Clone repo
-```
+
+```shell
 git clone https://github.com/NyanNyanovich/nyan
+cd nyan
 ```
 
-Install Python requirements
-```
+## Setup
+
+1. Create Telegram channel and linked discussion group: all this done in Telegram
+2. Create Telegram bot via BotFather: [installation doc](https://t.me/BotFather)
+3. Bot needs to be admin in both channel and group
+4. Provide Telegram API credentials to [configs/client_config.json](https://github.com/NyanNyanovich/nyan/blob/main/configs/client_config.json)
+
+## Fill in information about the channel and bot
+
+You need to edit the `configs/client_config.json` file. You can leave only `main` section for one channel. The number of sections and their names should be the same as in `configs/ranker_config.json`.
+
+### channel_id
+
+ID of the channel. For private channels can be obtained via any message link by right clicking on and selecting "Copy message link".
+Example message link: https://t.me/c/1770334618/2. For this link, the channel ID is: `1770334618`.
+For the Telegram format, you need to add the prefix `-100`.
+The final `channel_id` for the example is: `-1001770334618`.
+
+
+### discussion_id
+
+ID of the group with comments.
+It is built similarly to `channel_id`, only for the linked group.
+
+### bot_token
+
+Token, given when creating a bot. You just need to copy it.
+Usually it is in the `number:string` format.
+
+## Run option 1: Local Install
+
+This option suits better for developers.
+
+Install Python requirements. Create and activate `venv` before doing this.
+
+```shell
+python3 -m venv $(pwd)
+source ./bin/activate
 pip3 install -r requirements.txt
 ```
 
 Download models
-```
+
+```shell
 bash download_models.sh
 ```
 
-Install Docker and Docker Compose.
-* Docker instructions: https://docs.docker.com/engine/install
-* Docker Compose instructions: https://docs.docker.com/compose/install
-
-Provide Telegram API credentials to [configs/client_config.json](https://github.com/NyanNyanovich/nyan/blob/main/configs/client_config.json).
-
-## Run
+### Run
 
 Run Mongo container
-```
-docker-compose up
+
+```shell
+docker-compose run mongodb
 ```
 
 Run crawler
-```
+
+```shell
 bash crawl.sh
 ```
 
 Run server
-```
+
+```shell
 bash send.sh
+```
+
+## Run option 2: Run all in docker-compose
+
+This option is better to run as a service
+
+```shell
+docker-compose up
 ```

--- a/configs/mongo_container_config.json
+++ b/configs/mongo_container_config.json
@@ -1,0 +1,10 @@
+{
+    "client": {
+        "host": "mongodb://mongo",
+        "port": 27017
+    },
+    "database_name": "main",
+    "documents_collection_name": "documents",
+    "annotated_documents_collection_name": "annotated_documents",
+    "clusters_collection_name": "clusters"
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,27 @@ services:
     image: mongo:4.4.0
     container_name: mongo
     environment:
-        MONGO_INITDB_DATABASE: main
-    volumes:
-      - ./mongo:/data/db
+      MONGO_INITDB_DATABASE: main
     ports:
       - 27017:27017
+    volumes:
+      - ./mongo:/data/db
+    restart: always
+
+  nyan-send:
+    build: .
+    volumes:
+      - .:/usr/src/app
+    depends_on:
+      - mongo
+    restart: always
+    command: bash send_container.sh
+
+  nyan-crawl:
+    build: .
+    volumes:
+      - .:/usr/src/app
+    depends_on:
+      - mongo
+    restart: always
+    command: bash crawl.sh

--- a/send_container.sh
+++ b/send_container.sh
@@ -7,7 +7,7 @@ do
     python3 -m nyan.send \
         --channels-info-path channels.json \
         --client-config-path configs/client_config.json \
-        --mongo-config-path configs/mongo_config.json \
+        --mongo-config-path configs/mongo_container_config.json \
         --annotator-config-path configs/annotator_config.json \
         --renderer-config-path configs/renderer_config.json \
         --daemon-config-path configs/daemon_config.json;


### PR DESCRIPTION
Simpler way to run everything with just `docker-compose up`.
Documentation (translated and updated from wiki, sadly couldn't update the wiki too) and some improvements.

In order to keep both local and a new way to  run the service, I duplicated and modified `send.sh` and `configs/mongo_config.json`, but there should be a smarter way.