### PR TITLE
This PR updates the GitHub Actions workflow:

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -7,10 +7,10 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
     - name: Checkout github repo
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
       with:
         lfs: true
     - name: Set up Python 3.8


### PR DESCRIPTION
This PR updates the GitHub Actions workflow:

- Replaces `ubuntu-20.04` with `ubuntu-24.04` (latest LTS)
- Updates `actions/checkout` from `v3` to `v4`
- Keeps Python at version 3.8

Reason: `ubuntu-20.04` is deprecated and being removed from GitHub-hosted runners, which causes jobs to fail or be cancelled. This change ensures the CI remains stable and up to date.