### PR TITLE
Fix telesco.pe media URLs not working since August 7-8, 2025

### DIFF
--- a/nyan/client.py
+++ b/nyan/client.py
@@ -236,6 +236,12 @@ class TelegramClient:
         parse_mode: str = "html",
     ) -> Response:
         url_template = self.host + "/bot{}/sendPhoto"
+        
+        # TODO: TEMPORARY FIX - Replace telesco.pe with old CDN domain
+        # See issue #31 for proper long-term solutions
+        if "telesco.pe" in photo:
+            photo = photo.replace("telesco.pe", "cdn-telegram.org")
+        
         params = {
             "chat_id": issue.channel_id,
             "caption": text,
@@ -278,6 +284,12 @@ class TelegramClient:
         parse_mode: str = "html",
     ) -> Response:
         url_template = self.host + "/bot{}/sendVideo"
+        
+        # TODO: TEMPORARY FIX - Replace telesco.pe with old CDN domain
+        # See issue #31 for proper long-term solutions
+        if "telesco.pe" in video:
+            video = video.replace("telesco.pe", "cdn-telegram.org")
+        
         params = {
             "chat_id": issue.channel_id,
             "caption": text,
@@ -299,6 +311,16 @@ class TelegramClient:
         parse_mode: str = "html",
     ) -> Response:
         url_template = self.host + "/bot{}/sendMediaGroup"
+        
+        # TODO: TEMPORARY FIX - Replace telesco.pe with old CDN domain
+        # See issue #31 for proper long-term solutions
+        fixed_photos = []
+        for photo in photos:
+            if "telesco.pe" in photo:
+                fixed_photos.append(photo.replace("telesco.pe", "cdn-telegram.org"))
+            else:
+                fixed_photos.append(photo)
+        
         media = [
             {
                 "type": "photo",
@@ -306,7 +328,7 @@ class TelegramClient:
                 "caption": text if i == 0 else "",
                 "parse_mode": parse_mode,
             }
-            for i, photo in enumerate(photos)
+            for i, photo in enumerate(fixed_photos)
         ]
         params = {
             "chat_id": issue.channel_id,


### PR DESCRIPTION
## Problem

Since August 7-8, 2025, all media files (images and videos) fail to send via Bot API with errors like:
- "Bad Request: wrong type of the web page content"
- "Bad Request: failed to get HTTP URL content"
- "WEBPAGE_CURL_FAILED"

## Root Cause

Telegram migrated their CDN from `cdn4.cdn-telegram.org` to `cdn4.telesco.pe`. The new domain returns restrictive security headers:
- `content-security-policy: default-src 'none'; sandbox`
- `x-frame-options: DENY`
- `x-content-type-options: nosniff`

These headers block Bot API from accessing content directly.

## Solution

**Temporary fix**: Replace `telesco.pe` URLs with `cdn-telegram.org` which still works and serves the same content.

## Testing

✅ Tested with real production telesco.pe URLs  
✅ Successfully sends media that was failing before  
✅ No impact on non-telesco.pe URLs  
✅ Works for single photos, videos, and photo groups  

## Status

This is a **temporary fix**. The old CDN domain may eventually be discontinued. For proper long-term solutions see issue #31.

Fixes #31